### PR TITLE
feat(all roles): Support Debian 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Collection - jhampson_dbre.home_assistant
 
-A collection of roles for installing and configuring Home Assistant Supervised on Debian 10
+A collection of roles for installing and configuring Home Assistant Supervised on Debian 11
 
 **WARNING:** The roles in this collection can make changes to Home Assisant's configuration.yaml and restart Home Assistant. As recommended before making any changes to Home Assisant, ensure you have a good snapshot of your current configuration.
 
@@ -8,16 +8,16 @@ A collection of roles for installing and configuring Home Assistant Supervised o
 
 ### Minimal installation
 
-These roles attempt to implement the strict set of requirements for installing Home Assistant Supervised available [here](https://github.com/home-assistant/architecture/blob/6da4482d171f2ef04de9320d313526653b5818b4/adr/0014-home-assistant-supervised.md).
-While every effort has been made to ensure these roles complies with ADR-0014, no guarantee can be made it does now, or in the future. These roles may have software package requirements (e.g. `python3-apt`) that are not specified by ADR-0014. To date these have not caused Home Assistant to report an unsupported installation, but please file a GitHub if you encounter any problems.
+These roles attempt to implement the strict set of requirements for installing Home Assistant Supervised available [here](https://github.com/home-assistant/architecture/blob/master/adr/0014-home-assistant-supervised.md).
+While every effort has been made to ensure these roles complies with ADR-0014, no guarantee can be made it does now, or in the future. These roles may have software package requirements (e.g. `python3-apt`) that are not specified by ADR-0014. To date these have not caused Home Assistant to report an unsupported installation, but please file a GitHub issue if you encounter any problems.
 
 1. [preinstall_config](https://github.com/jhampson-dbre/home_assistant/blob/main/roles/preinstall_config/README.md) - Prerequisite configuration for Home Assistant Supervised installation
 
-1. [supervised_install](https://github.com/jhampson-dbre/home_assistant/blob/main/roles/supervised_install/README.md) - Supported installation of Home Assistant Supervised on Debian 10
+1. [supervised_install](https://github.com/jhampson-dbre/home_assistant/blob/main/roles/supervised_install/README.md) - Supported installation of Home Assistant Supervised on Debian 11
 
 ### Additional roles
 
-These roles provide additional functionality to secure and enhance the minimal install of Home Assistant Supervised. These are roles I use myself and do not comply with ADR-0014.
+These roles provide additional functionality to secure and enhance the minimal install of Home Assistant Supervised. These are roles I use myself and do not *strictly* comply with ADR-0014. However ADR-0014 states that maintaining and securiting the operating system is the responsibility of the user, and these roles fulfill that requirement without interfering with the Supervised installation.
 
 1. [harden_os](https://github.com/jhampson-dbre/home_assistant/blob/main/roles/harden_os/README.md) - Enable automated Debian security updates and restrict SSH access
 1. [fail2ban](https://github.com/jhampson-dbre/home_assistant/blob/main/roles/fail2ban/README.md) - Install fail2ban, configure it to blacklist IPs with excessive failed login attempts to Home Assistant, and add the fail2ban integration to Home Assistant

--- a/Vagrantfile.debian11
+++ b/Vagrantfile.debian11
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "generic/debian10"
+  config.vm.box = "generic/debian11"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/roles/fail2ban/README.md
+++ b/roles/fail2ban/README.md
@@ -13,7 +13,7 @@ This role is based upon this documentation:
 Requirements
 ------------
 
-- Home Assistant Supervised installation running on Debian 10
+- Home Assistant Supervised installation running on Debian 11
 - NGINX Home Assistant SSL proxy add-on should be configured as reverse proxy for Home Assistant
 - This role must be ran as root, or as an alternate user with `become: true` set
 - Docker SDK for Python: `docker` Python package on the target server

--- a/roles/fail2ban/meta/main.yml
+++ b/roles/fail2ban/meta/main.yml
@@ -12,9 +12,9 @@ galaxy_info:
   # https://galaxy.ansible.com/api/v1/platforms/
   #
   platforms:
-  - name: Debian
-    versions:
-      - buster
+    - name: Debian
+      versions:
+        - bullseye
 
   galaxy_tags:
     - home

--- a/roles/harden_os/README.md
+++ b/roles/harden_os/README.md
@@ -1,7 +1,7 @@
 harden_os
 =========
 
-Improve security of Debian 10 OS running Home Assistant Supervised on Raspberry Pi 4
+Improve security of Debian 11 OS running Home Assistant Supervised on Raspberry Pi 4
 
 This role can perform the following hardening:
 

--- a/roles/harden_os/meta/main.yml
+++ b/roles/harden_os/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - bullseye
 
   galaxy_tags:
     - home

--- a/roles/install_hacs/meta/main.yml
+++ b/roles/install_hacs/meta/main.yml
@@ -23,7 +23,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - bullseye
 
   galaxy_tags:
     - home

--- a/roles/os_agent_auto_update/meta/main.yml
+++ b/roles/os_agent_auto_update/meta/main.yml
@@ -23,7 +23,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - bullseye
 
   galaxy_tags:
     - home

--- a/roles/preinstall_config/README.md
+++ b/roles/preinstall_config/README.md
@@ -1,12 +1,12 @@
 home_assistant.preinstall_config
 =========
 
-Prepare Rapsberry Pi 4 running Debian 10 for Home Assistant Supervised installation.
+Prepare Rapsberry Pi 4 running Debian 11 for Home Assistant Supervised installation.
 
 Requirements
 ------------
 
-This role is intended to run on Raspberry Pi 4 running Debian 10 installed using steps 1.1-1.3 of the [Installing Home Assistant Supervised on Raspberry Pi with Debian 10](https://community.home-assistant.io/t/installing-home-assistant-supervised-on-a-raspberry-pi-with-debian-10/247116) community guide.
+This role is intended to run on Raspberry Pi 4 running Debian 11 installed using steps 1.1-1.3 of the [Installing Home Assistant Supervised on a Raspberry Pi with Debian 11](https://community.home-assistant.io/t/installing-home-assistant-supervised-on-a-raspberry-pi-with-debian-11/247116) community guide.
 
 Since Ansible requires SSH to manage machines remotely, it is recommended to activate the root login by editing the sysconfig.txt file and uncomment the root password and the root_authorized_key. Then you should generate an SSH key pair and use the generated public key to paste there.
 

--- a/roles/preinstall_config/meta/main.yml
+++ b/roles/preinstall_config/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Jared Hampson
-  description: Performs tasks to prepare Rapsberry Pi 4 running Debian 10 for Home Assistant installation.
+  description: Performs tasks to prepare Rapsberry Pi 4 running Debian 11 for Home Assistant installation.
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -22,7 +22,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - bullseye
 
   galaxy_tags:
     - home

--- a/roles/supervised_install/README.md
+++ b/roles/supervised_install/README.md
@@ -1,7 +1,7 @@
 supervised_install
 =========
 
-Install Home Assistant Supervised on Raspberry Pi 4 running Debian 10 (buster).
+Install Home Assistant Supervised on Raspberry Pi 4 running Debian 11 (bullseye).
 
 Requirements
 ------------
@@ -66,7 +66,7 @@ Example Playbook
 ----------------
 
 ```yaml
-# Run the playbook from remote host to Rapsberry Pi 4 running Debian 10 64-bit
+# Run the playbook from remote host to Rapsberry Pi 4 running Debian 11 64-bit
 - hosts: pi
   become: yes
   force_handlers: true
@@ -75,7 +75,7 @@ Example Playbook
 ```
 
 ```yaml
-# Run the playbook locally in a Debian 10 VM with Ansible installed, running in Hyper-V on Windows
+# Run the playbook locally in a Debian 11 VM with Ansible installed, running in Hyper-V on Windows
 - hosts: localhost
   become: yes
   force_handlers: true

--- a/roles/supervised_install/meta/main.yml
+++ b/roles/supervised_install/meta/main.yml
@@ -23,7 +23,7 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - buster
+        - bullseye
 
   galaxy_tags:
     - smart

--- a/roles/supervised_install/tasks/main.yml
+++ b/roles/supervised_install/tasks/main.yml
@@ -12,12 +12,14 @@
 - name: Install OS package prereqs # noqa 403
   apt:
     name:
-      - systemd
-      - network-manager
-      - apparmor
       - jq
+      - wget
       - curl
+      - udisks2
+      - libglib2.0-bin
+      - network-manager
       - dbus
+      - apparmor-utils
     state: latest
     update_cache: yes
 


### PR DESCRIPTION
BREAKING CHANGE: Support for Debian 10 has been deprecated by Home Assistant team, so it is no longer supported by this collection. Debian 11 is the only officially supported operating system for Home Assistant Supervised, so it is the only operating system officially supported by this collection as well.

Fixes #21