### PR TITLE
fix(harden_os): Fix unattended-upgrades with Debian 11

### DIFF
--- a/roles/harden_os/templates/50unattended-upgrades.j2
+++ b/roles/harden_os/templates/50unattended-upgrades.j2
@@ -20,6 +20,7 @@ Unattended-Upgrade::Allowed-Origins {
 Unattended-Upgrade::Origins-Pattern {
         "origin=${distro_id},codename=${distro_codename},label=${distro_id}";
         "origin=${distro_id},codename=${distro_codename},label=${distro_id}-Security";
+        "origin=${distro_id},codename=${distro_codename}-security,label=${distro_id}-Security";
 };
 
 // Python regular expressions, matching packages to exclude from upgrading


### PR DESCRIPTION
In Debian 11, the security archive layout was changed, requiring `-security` to be added to the origins pattern.

Fixes #38