### PR TITLE
fix(os_agent_auto_update): Use full path to ansible-playbook in cron command

### DIFF
--- a/roles/os_agent_auto_update/README.md
+++ b/roles/os_agent_auto_update/README.md
@@ -15,8 +15,12 @@ Role Variables
 The following varaibles are defined in `defaults/main.yml`
 
 ```yaml
-# The path that the automatic update playbook will be copied to for scheduling
-os_agent_auto_update_playbook_dir: /home/homeassistant/playbooks
+# The directory that the automatic update playbook will be copied to for scheduling
+os_agent_auto_update_playbook_dir: /home/homeassistant/playbooks/
+
+# The directory that the `ansible-playbook` command is in
+# Default is for user pip install for root user
+os_agent_ansible_playbook_cmd_dir: /root/.local/bin/
 
 # Install ansible on the remote host so that the update playbook can run in cron. Set to false to you already have ansible installed, or need a specific Ansible version.
 os_agent_auto_update_install_ansible: true

--- a/roles/os_agent_auto_update/defaults/main.yml
+++ b/roles/os_agent_auto_update/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 # defaults file for os_agent_auto_update
-os_agent_auto_update_playbook_dir: /home/homeassistant/playbooks
+os_agent_auto_update_playbook_dir: /home/homeassistant/playbooks/
+os_agent_ansible_playbook_cmd_dir: /root/.local/bin/
 os_agent_auto_update_install_ansible: true

--- a/roles/os_agent_auto_update/tasks/main.yml
+++ b/roles/os_agent_auto_update/tasks/main.yml
@@ -24,4 +24,4 @@
     name: "update OS Agent"
     minute: "0"
     hour: "5"
-    job: "ansible-playbook {{ os_agent_auto_update_playbook_dir }}/update_os_agent.yml"
+    job: "{{ os_agent_ansible_playbook_cmd_dir }}ansible-playbook {{ os_agent_auto_update_playbook_dir }}update_os_agent.yml"


### PR DESCRIPTION
Fixes #50