### PR TITLE
fix(syntax): remove deprecated `warn` arg from shell tasks

### DIFF
--- a/roles/fail2ban/handlers/main.yml
+++ b/roles/fail2ban/handlers/main.yml
@@ -8,5 +8,3 @@
 - name: restart home assistant
   shell: |
     ha core restart
-  args:
-    warn: no

--- a/roles/harden_os/tasks/patching.yml
+++ b/roles/harden_os/tasks/patching.yml
@@ -17,7 +17,6 @@
   args:
     creates: /etc/apt/apt.conf.d/20auto-upgrades
     executable: /bin/bash
-    warn: no
 
 - name: Configure unattended upgrades
   template:

--- a/roles/install_hacs/handlers/main.yml
+++ b/roles/install_hacs/handlers/main.yml
@@ -1,5 +1,3 @@
 - name: restart home assistant
   shell: |
     ha core restart
-  args:
-    warn: false

--- a/roles/preinstall_config/tasks/main.yml
+++ b/roles/preinstall_config/tasks/main.yml
@@ -28,8 +28,6 @@
         fi
       register: switch_to_cgroup_v1
       changed_when: switch_to_cgroup_v1.stdout is search('Switching to cgroup v1')
-      args:
-        warn: false
 
   when: firmware_cmdline.stat.exists | bool
 

--- a/roles/supervised_install/tasks/main.yml
+++ b/roles/supervised_install/tasks/main.yml
@@ -50,8 +50,6 @@
         ping -c 3 -6 version.home-assistant.io
       check_mode: false
       changed_when: false
-      args:
-        warn: false
   rescue:
     - name: Disable IPv6 to prevent Home Assistant install hang
       ansible.builtin.lineinfile:
@@ -83,7 +81,8 @@
       when: resolve_conf_override_result is changed
   when: supervised_install_resolve_conf_overrides is defined
 
-- name: Get download url for latest os-agent .deb release
+# use shell module so we can parse the output with shell commands
+- name: Get download url for latest os-agent .deb release # noqa: command-instead-of-module
   shell: |
     curl -s https://api.github.com/repos/home-assistant/os-agent/releases/latest \
     | grep "browser_download_url.*{{ arch[ansible_architecture]['os_agent'] }}.deb" \
@@ -92,9 +91,7 @@
   register: os_agent_latest_url
   failed_when: os_agent_latest_url.stdout is not search('os-agent_.*_linux_.*.deb')
   changed_when: false
-  check_mode: no
-  args:
-    warn: false
+  check_mode: false
 
 - name: Install os-agent
   apt:


### PR DESCRIPTION
fixes #56 